### PR TITLE
das2json: fix syntax error with latest Odin release

### DIFF
--- a/das2json/syntax/drawio_mxgraph.odin
+++ b/das2json/syntax/drawio_mxgraph.odin
@@ -93,12 +93,12 @@ page_from_elem :: proc(doc: ^xml.Document, elem: xml.Element) -> (page: Page) {
     slice.sort_by(page.cells, proc(i, j: Cell) -> bool {
         return i.type < j.type
     })
-    for cell, idx in &page.cells {
+    for &cell, idx in &page.cells {
         cell.id = idx
     }
 
     // connect source/target references etc.
-    for cell in &page.cells {
+    for &cell in &page.cells {
         for x in page.cells {
             if cell.mxgraph_source == x.mxgraph_id {
                 cell.source = x.id


### PR DESCRIPTION
Before, with `odin version dev-2025-04-nightly`:
![image](https://github.com/user-attachments/assets/d1d5b4e8-fc50-4748-b790-b3b31176e317)

After:
```
#0 11:13:45 ^ main ~/code/guitarvydas/0D/das2json>make clean
rm -rf das2json *.bin *.dSYM *.drawio.json
#0 11:14:12 ^ main ~/code/guitarvydas/0D/das2json>odin version
odin version dev-2025-04-nightly
#0 11:14:15 ^ main ~/code/guitarvydas/0D/das2json>make
odin build . -debug -o:none
#0 11:14:18 ^ main ~/code/guitarvydas/0D/das2json>
```